### PR TITLE
quick fix for refresh() when not applicable

### DIFF
--- a/viewport-units-buggyfill.js
+++ b/viewport-units-buggyfill.js
@@ -27,10 +27,12 @@
   var dimensions;
   var declarations;
   var styleNode;
+  var applicable = true;
 
   function initialize(force) {
     if (!force && !/ip.+mobile.+safari/i.test(window.navigator.userAgent)) {
       // this buggyfill only applies to mobile safari
+      applicable = false;
       return;
     }
     
@@ -47,8 +49,10 @@
   }
 
   function refresh() {
-    findProperties();
-    updateStyles();
+    if(applicable) {
+      findProperties();
+      updateStyles();
+    }
   }
 
   function findProperties() {


### PR DESCRIPTION
Fixes issue that fires errors on viewportUnitsBuggyfill.refresh() when userAgent is not mobile Safari. Just a quick fix, perhaps some refactoring would be better.
