### PR TITLE
Adding UIWebView auto initialization of buggyfill.

### DIFF
--- a/viewport-units-buggyfill.js
+++ b/viewport-units-buggyfill.js
@@ -28,9 +28,10 @@
   var dimensions;
   var declarations;
   var styleNode;
+  var is_safari_or_uiwebview = /(iPhone|iPod|iPad).+AppleWebKit/i.test(window.navigator.userAgent);
 
   function initialize(force) {
-    if (initialized || (!force && !/ip.+mobile/i.test(window.navigator.userAgent))) {
+    if (initialized || (!force && !is_safari_or_uiwebview)) {
       // this buggyfill only applies to mobile safari
       return;
     }


### PR DESCRIPTION
UIWebView has the same issues as Mobile Safari when using viewport
units. This change makes the regex that matches Mobile Safari more
generic to match what UIWebViews report in iOS.

Tested on:
- iOS Simulator UIWebView
- iOS Simulator Mobile Safari
- iOS 7 Mobile Safari
- iOS Twitter
  Client UIWebView.

UIWebView User Agent

```
"Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Mobile/11D167"
```

Mobile Safari User Agent

```
"Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/7.0 Mobile/11D167 Safari/9537.53"
```
