### PR TITLE
Allow iOS8 safari to use native viewport units, which seem to be support...

### DIFF
--- a/viewport-units-buggyfill.js
+++ b/viewport-units-buggyfill.js
@@ -32,6 +32,15 @@
   var styleNode;
   var isOldInternetExplorer = false;
 
+  var isOldMobileSafari = false;
+
+  if (isMobileSafari) {
+    var versions = /Version\/(\d+)/.exec(window.navigator.userAgent)
+    if (versions.length > 1 && parseInt(versions[1]) < 8) {
+      isOldMobileSafari = true;
+    }
+  }
+
   // Do not remove the following comment!
   // It is a conditional comment used to
   // identify old Internet Explorer versions
@@ -81,7 +90,7 @@
     options = initOptions || {};
     options.isMobileSafari = isMobileSafari;
 
-    if (!options.force && !isMobileSafari && !isOldInternetExplorer && (!options.hacks || !options.hacks.required(options))) {
+    if (!options.force && !isOldMobileSafari && !isOldInternetExplorer && (!options.hacks || !options.hacks.required(options))) {
       // this buggyfill only applies to mobile safari
       return;
     }


### PR DESCRIPTION
...ed

@rodneyrehm iOS8 Safari seems to behave correctly with vh, vw, calc with these units, etc.  Here's a branch allowing iOS8 to run free.  Feel free to use/modify if you'd like.
