### PR TITLE
Uses a more reliable pattern to match the iOS major version number, also...

### DIFF
--- a/viewport-units-buggyfill.js
+++ b/viewport-units-buggyfill.js
@@ -34,8 +34,8 @@
   var isOperaMini = userAgent.indexOf('Opera Mini') > -1;
   var isMobileSafari = /(iPhone|iPod|iPad).+AppleWebKit/i.test(userAgent) && (function() {
     // viewport units work fine in mobile Safari on iOS 8+
-    var versions = /Version\/(\d+)/.exec(window.navigator.userAgent);
-    return versions.length > 1 && parseInt(versions[1]) < 8;
+    var versions = /OS (\d+)/i.exec(window.navigator.userAgent);
+    return versions === null || (versions.length > 1 && parseInt(versions[1]) < 8);
   })();
   var isBadStockAndroid = (function() {
     // Android stock browser test derived from


### PR DESCRIPTION
... implements a fallback if none is found. See listing for details: http://www.webapps-online.com/online-tools/user-agent-strings/dv/operatingsystem51849/ios

The issue appeared when testing on the iOS 7 simulator and on a device where the UserAgent would of the form:
Mozilla/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Mobile/11A465

The pattern matching the iOS major version would seek /Version\/(\d+)/, which wouldn't match. The new pattern matches /OS (\d+)/i, and defaults to using viewport-units-buggyfill if not matched.
