### PR TITLE
Ensure injected node stays below when updating

### DIFF
--- a/viewport-units-buggyfill.js
+++ b/viewport-units-buggyfill.js
@@ -154,6 +154,8 @@
 
   function updateStyles() {
     styleNode.textContent = getReplacedViewportUnits();
+    // move to the end in case inline <style>s were added dynamically
+    styleNode.parentNode.appendChild(styleNode);
   }
 
   function refresh() {


### PR DESCRIPTION
This fixes a problem when using this buggyfill with dynamic CSS loaders that add `<style>` tags. I can call `refresh` but unless I also move style tag, its precedence is lower and it doesn't have effect.