### PR TITLE
2015 Updates

### DIFF
--- a/viewport-units-buggyfill.js
+++ b/viewport-units-buggyfill.js
@@ -1,4 +1,4 @@
-/*! 
+/*!
  * viewport-units-buggyfill v0.2.2
  * @web: https://github.com/rodneyrehm/viewport-units-buggyfill/
  * @author: Rodney Rehm - http://rodneyrehm.de/en/
@@ -38,11 +38,11 @@
     initialized = true;
     styleNode = document.createElement('style');
     styleNode.id = 'patched-viewport';
-    document.head.appendChild(styleNode);
+    document.body.appendChild(styleNode);
 
     //window.addEventListener('orientationchange', updateStyles, true);
     // doing a full refresh rather than updateStyles because an orientationchange
-    // could activate different stylesheets 
+    // could activate different stylesheets
     window.addEventListener('orientationchange', refresh, true);
     refresh();
   }

--- a/viewport-units-buggyfill.js
+++ b/viewport-units-buggyfill.js
@@ -30,7 +30,7 @@
   var styleNode;
 
   function initialize(force) {
-    if (initialized || (!force && !/ip.+mobile.+safari/i.test(window.navigator.userAgent))) {
+    if (initialized || (!force && !/ip.+version\/(7|6).+mobile.+safari/i.test(window.navigator.userAgent))) {
       // this buggyfill only applies to mobile safari
       return;
     }


### PR DESCRIPTION
This updates the user agent sniff to ignore iOS 8 and moves the style append to the end of the body instead of the head to be compatible with the trend of late loading stylesheets for network performance.