### PR TITLE
Update viewport-units-buggyfill.js

### DIFF
--- a/viewport-units-buggyfill.js
+++ b/viewport-units-buggyfill.js
@@ -365,7 +365,7 @@
     };
 
     forEach.call(document.styleSheets, function(sheet) {
-      if (!sheet.href || origin(sheet.href) === origin(location.href)) {
+      if (!sheet.href || origin(sheet.href) === origin(location.href) || sheet.ownerNode.getAttribute('data-viewport-units-buggyfill') === 'ignore') {
         // skip <style> and <link> from same origin
         return;
       }


### PR DESCRIPTION
Problem:
CSS from CDN does not work (CORS error) even if we add data-viewport-units-buggyfill="ignore" as attribute in link tag

Solution:
Add data-viewport-units-buggyfill="ignore" for importCrossOriginLinks function to skip import cross origin links.