### PR TITLE
Grunt version wasn't valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "jshint-stylish": "~0.1.5",
-    "grunt": "~0.5.1",
+    "grunt": "~0.4.5",
     "grunt-contrib-jshint": "~0.8.0"
   }
 }


### PR DESCRIPTION
Looks like it was change when repo version matched the version of grunt used. Most likely via a find and replace all ;)