### PR TITLE
New simple and hacky check for IE 10 since rv is only working for IE 11.

### DIFF
--- a/viewport-units-buggyfill.hacks.js
+++ b/viewport-units-buggyfill.hacks.js
@@ -34,7 +34,7 @@
   // added check for IE10, IE11 and Edge < 20, since it *still* doesn't understand vmax
   // http://caniuse.com/#feat=viewport-units
   if (!isBuggyIE) {
-    isBuggyIE = !!navigator.userAgent.match(/Trident.*rv[ :]*1[01]\.| Edge\/1\d\./);
+    isBuggyIE = !!navigator.userAgent.match(/MSIE 10\.|Trident.*rv[ :]*1[01]\.| Edge\/1\d\./);
   }
 
   if (isBuggyIE === true) {

--- a/viewport-units-buggyfill.js
+++ b/viewport-units-buggyfill.js
@@ -69,7 +69,7 @@
   // added check for IE10, IE11 and Edge < 20, since it *still* doesn't understand vmax
   // http://caniuse.com/#feat=viewport-units
   if (!isBuggyIE) {
-    isBuggyIE = !!navigator.userAgent.match(/Trident.*rv[ :]*1[01]\.| Edge\/1\d\./);
+    isBuggyIE = !!navigator.userAgent.match(/MSIE 10\.|Trident.*rv[ :]*1[01]\.| Edge\/1\d\./);
   }
 
   // Polyfill for creating CustomEvents on IE9/10/11


### PR DESCRIPTION
Uses the same user agent sniffing as used for IE9. See #68.