### PR TITLE
Add support for @supports query.

### DIFF
--- a/viewport-units-buggyfill.js
+++ b/viewport-units-buggyfill.js
@@ -367,8 +367,15 @@
 
     var _rule = rule.parentRule;
     while (_rule) {
-      _selectors.unshift('@media ' + _rule.media.mediaText);
-      _rule = _rule.parentRule;
+      if(_rule.media) { // check if _rule contain media-query 
+        _selectors.unshift('@media ' + _rule.media.mediaText);
+        _rule = _rule.parentRule;
+      } else { // check if _rule contain support-query
+        if (_rule.conditionText) {
+          _selectors.unshift('@supports ' + _rule.conditionText);
+          _rule = _rule.parentRule;
+        }
+      }
     }
 
     return {


### PR DESCRIPTION
Hello! 

I added **viewport-units-buggyfill** to one my project and found that it doesn't procces **@supports queries**. In this request I made a solution, which worked for me, hope it will help other people and will be good thing for new minor version of  **viewport-units-buggyfill**.