### PR TITLE
Makes sure that the property of a style is  not an url

### DIFF
--- a/viewport-units-buggyfill.js
+++ b/viewport-units-buggyfill.js
@@ -26,6 +26,7 @@
   var options;
   var userAgent = window.navigator.userAgent;
   var viewportUnitExpression = /([+-]?[0-9.]+)(vh|vw|vmin|vmax)/g;
+  var urlExpression = /(https?:)?\/\//
   var forEach = [].forEach;
   var dimensions;
   var declarations;
@@ -289,7 +290,7 @@
       }
 
       viewportUnitExpression.lastIndex = 0;
-      if (viewportUnitExpression.test(value)) {
+      if (viewportUnitExpression.test(value) && !urlExpression.test(value)) {
         declarations.push([rule, name, value]);
         options.hacks && options.hacks.findDeclarations(declarations, rule, name, value);
       }


### PR DESCRIPTION
Hello,

just had this issue that made me sweat for a while today.
Please let me know if I need to do anything else to get this PR merged.

Commit msg
------------
I actually got a bug with background-image property
pointing to cloudfront with this url:
  https://d3r0d0kb2vhuxd.cloudfront.net

The viewportUnitExpression regex matched the url
and the url got rewritten.

This is a fix to avoid that.