### PR TITLE
match properly iOS 10+ version

### DIFF
--- a/viewport-units-buggyfill.js
+++ b/viewport-units-buggyfill.js
@@ -44,7 +44,7 @@
       // Example Safari UserAgents:
       // * Safari iOS8: "Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/600.1.3 (KHTML, like Gecko) Version/8.0 Mobile/12A4345d Safari/600.1.4"
       // * Safari iOS7: "Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A4449d Safari/9537.53"
-      var iOSversion = userAgent.match(/OS (\d)/);
+      var iOSversion = userAgent.match(/OS (\d+)/);
       // viewport units work fine in mobile Safari and webView on iOS 8+
       return iOSversion && iOSversion.length > 1 && parseInt(iOSversion[1]) < 10;
     })();


### PR DESCRIPTION
UserAgent:
`Mozilla/5.0 (iPhone; CPU iPhone OS 10_0 like Mac OS X) AppleWebKit/602.1.38 (KHTML, like Gecko) Version/10.0 Mobile/14A300 Safari/602.1`

Before: `["OS 1", "1"]`
After:`["OS 10", "10"]`