### PR TITLE
specify the viewport width & height , to fit some special cases

### DIFF
--- a/viewport-units-buggyfill.js
+++ b/viewport-units-buggyfill.js
@@ -392,8 +392,8 @@
     }
 
     function getViewport() {
-      var vh = window.innerHeight;
-      var vw = window.innerWidth;
+      var vh = options.innerHeight || window.innerHeight;
+      var vw = options.innerWidth || window.innerWidth;
 
       return {
         vh: vh,


### PR DESCRIPTION
Some chrome extensions may insert my mobile page into a wider page , so I'd like to specify my `innerWidth` and `innerHeight`.