### PR TITLE
fix: viewport units support ios8+, but the iosVersion fix detect as i…

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,8 @@
 # Viewport Units Buggyfill™
 
+> This is an form from Viewport Units Buggyfill
+> Because the package didnot works right on iOS
+
 This is a *buggyfill* (fixing bad behavior), not a *polyfill* (adding missing behavior). That said, it provides hacks for you to get viewport units working in old IE and Android Stock Browser as well. If the browser doesn't know how to deal with the [viewport units](http://www.w3.org/TR/css3-values/#viewport-relative-lengths) - `vw`, `vh`, `vmin` and `vmax` - this library will not improve the situation unless you're using the hacks detailed below. The buggyfill uses the [CSSOM](http://dev.w3.org/csswg/cssom/) to access the defined styles rather than ship its own CSS parser, that'S why the hacks abuse the CSS property `content` to get the values across.
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,13 +1,10 @@
 {
-  "name": "viewport-units-buggyfill",
-  "version": "0.6.2",
+  "name": "viewport-units-buggyfill2",
+  "version": "0.7.2",
   "title": "Viewport Units Buggyfill for Mobile Safari",
-  "description": "Making viewport units (vh|vw|vmin|vmax) work properly in older WebKit and Trident",
+  "description": "Making viewport units (vh|vw|vmin|vmax) work properly in older WebKit and Trident. fork from viewport-units-buggyfill",
   "homepage": "http://github.com/rodneyrehm/viewport-units-buggyfill/",
-  "author": {
-    "name": "Rodney Rehm",
-    "url": "http://rodneyrehm.de"
-  },
+  "author": "norfish <easumlee@gmail.com> (http://jspie.com/)",
   "contributors": [
     {
       "name": "Zoltan Hawryluk",

--- a/viewport-units-buggyfill.js
+++ b/viewport-units-buggyfill.js
@@ -46,7 +46,7 @@
       // * Safari iOS7: "Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A4449d Safari/9537.53"
       var iOSversion = userAgent.match(/OS (\d+)/);
       // viewport units work fine in mobile Safari and webView on iOS 8+
-      return iOSversion && iOSversion.length > 1 && parseInt(iOSversion[1]) < 10;
+      return iOSversion && iOSversion.length > 1 && parseInt(iOSversion[1]) < 8;
     })();
 
     var isBadStockAndroid = (function() {


### PR DESCRIPTION
when I search in caniuse: https://caniuse.com/#search=viewport
viewport units wokrs find on iOS8 and iOS8+

and I found that, the comment is also said:
```
var isMobileSafari = /(iPhone|iPod|iPad).+AppleWebKit/i.test(userAgent) && (function() {
      // Regexp for iOS-version tested against the following userAgent strings:
      // Example WebView UserAgents:
      // * iOS Chrome on iOS8: "Mozilla/5.0 (iPad; CPU OS 8_1 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) CriOS/39.0.2171.50 Mobile/12B410 Safari/600.1.4"
      // * iOS Facebook on iOS7: "Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_1 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Mobile/11D201 [FBAN/FBIOS;FBAV/12.1.0.24.20; FBBV/3214247; FBDV/iPhone6,1;FBMD/iPhone; FBSN/iPhone OS;FBSV/7.1.1; FBSS/2; FBCR/AT&T;FBID/phone;FBLC/en_US;FBOP/5]"
      // Example Safari UserAgents:
      // * Safari iOS8: "Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/600.1.3 (KHTML, like Gecko) Version/8.0 Mobile/12A4345d Safari/600.1.4"
      // * Safari iOS7: "Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A4449d Safari/9537.53"
      var iOSversion = userAgent.match(/OS (\d+)/);
      // viewport units work fine in mobile Safari and webView on iOS 8+
      return iOSversion && iOSversion.length > 1 && parseInt(iOSversion[1]) < 10;
    })();
```
but why the return valud satement detect as iOS10-. 

I think this would cost some unused works on iOS8+

#101 